### PR TITLE
Add user updation feature #5

### DIFF
--- a/FlexiForm.API/Attributes/APIExceptionFilterAttribute.cs
+++ b/FlexiForm.API/Attributes/APIExceptionFilterAttribute.cs
@@ -67,6 +67,8 @@ namespace FlexiForm.API.Attributes
                 ErrorCode.StrongPasswordRequired => HttpStatusCode.BadRequest,
                 ErrorCode.UserNotFound => HttpStatusCode.NotFound,
                 ErrorCode.InvalidCredentials => HttpStatusCode.Unauthorized,
+                ErrorCode.InvalidGender => HttpStatusCode.BadRequest,
+                ErrorCode.GenderRequired => HttpStatusCode.BadRequest,
                 _ => HttpStatusCode.BadRequest
             };
         }

--- a/FlexiForm.API/Controllers/UsersController.cs
+++ b/FlexiForm.API/Controllers/UsersController.cs
@@ -61,5 +61,26 @@ namespace FlexiForm.API.Controllers
             };
             return Ok(apiResponse);
         }
+
+        /// <summary>
+        /// Updates an existing user's information based on the provided user ID and update request.
+        /// </summary>
+        /// <param name="id">The unique identifier of the user to update.</param>
+        /// <param name="request">The <see cref="UserUpdateRequest"/> object containing the updated user details.</param>
+        /// <returns>
+        /// An <see cref="IActionResult"/> containing a success response with the updated <see cref="UserResponse"/> data.
+        /// Returns <c>200 OK</c> if the update is successful.
+        /// </returns>
+        [Authorize(Policy = AuthorizationPolicy.ProfileOwner)]
+        [HttpPut("{id:int}")]
+        public async Task<IActionResult> Update([FromRoute] int id, [FromBody] UserUpdateRequest request)
+        {
+            var response = await _service.UpdateAsync(id, request);
+            var apiResponse = new APIResponse<UserResponse>()
+            {
+                Data = response
+            };
+            return Ok(apiResponse);
+        }
     }
 }

--- a/FlexiForm.API/DTOs/Requests/UserUpdateRequest.cs
+++ b/FlexiForm.API/DTOs/Requests/UserUpdateRequest.cs
@@ -20,6 +20,6 @@ namespace FlexiForm.API.DTOs.Requests
         /// <summary>
         /// Gets or sets the user's gender.
         /// </summary>
-        public Gender? Gender { get; set; }
+        public Gender Gender { get; set; }
     }
 }

--- a/FlexiForm.API/DTOs/Requests/UserUpdateRequest.cs
+++ b/FlexiForm.API/DTOs/Requests/UserUpdateRequest.cs
@@ -1,0 +1,25 @@
+﻿using FlexiForm.API.Enumerations;
+
+namespace FlexiForm.API.DTOs.Requests
+{
+    /// <summary>
+    /// Represents the request payload for updating a user's profile information.
+    /// </summary>
+    public class UserUpdateRequest
+    {
+        /// <summary>
+        /// Gets or sets the user's first name.
+        /// </summary>
+        public string? FirstName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's last name.
+        /// </summary>
+        public string? LastName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's gender.
+        /// </summary>
+        public Gender? Gender { get; set; }
+    }
+}

--- a/FlexiForm.API/Enumerations/ErrorCode.cs
+++ b/FlexiForm.API/Enumerations/ErrorCode.cs
@@ -63,6 +63,16 @@
         /// <summary>
         /// While logging in either wrong email or password is given.
         /// </summary>
-        InvalidCredentials = 1010
+        InvalidCredentials = 1010,
+
+        /// <summary>
+        /// An invalid gender is given which is not part of the <see cref="Gender"/>.
+        /// </summary>
+        InvalidGender = 1011,
+
+        /// <summary>
+        /// Gender is required for the user.
+        /// </summary>
+        GenderRequired = 1012
     }
 }

--- a/FlexiForm.API/Enumerations/Gender.cs
+++ b/FlexiForm.API/Enumerations/Gender.cs
@@ -6,6 +6,11 @@
     public enum Gender
     {
         /// <summary>
+        /// Indicates no value is given.
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Indicates a male user.
         /// </summary>
         Male,

--- a/FlexiForm.API/Exceptions/GenderRequiredException.cs
+++ b/FlexiForm.API/Exceptions/GenderRequiredException.cs
@@ -1,0 +1,19 @@
+﻿using FlexiForm.API.Enumerations;
+
+namespace FlexiForm.API.Exceptions
+{
+    /// <summary>
+    /// Represents an exception that is thrown when the gender value is not provided in a request where it is required.
+    /// </summary>
+    public class GenderRequiredException : BaseException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenderRequiredException"/> class
+        /// with a predefined error message indicating that gender is required.
+        /// </summary>
+        public GenderRequiredException()
+            : base(ErrorCode.GenderRequired, "Gender is required and must be provided.")
+        {
+        }
+    }
+}

--- a/FlexiForm.API/Exceptions/InvalidGenderException.cs
+++ b/FlexiForm.API/Exceptions/InvalidGenderException.cs
@@ -1,0 +1,20 @@
+﻿using FlexiForm.API.Enumerations;
+
+namespace FlexiForm.API.Exceptions
+{
+    /// <summary>
+    /// Represents an exception that is thrown when an invalid gender value is provided.
+    /// </summary>
+    public class InvalidGenderException : BaseException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidGenderException"/> class
+        /// with the specified invalid gender.
+        /// </summary>
+        /// <param name="gender">The gender value that caused the exception.</param>
+        public InvalidGenderException(Gender gender)
+            : base(ErrorCode.InvalidGender, $"The given gender '{gender}' is not valid.")
+        {
+        }
+    }
+}

--- a/FlexiForm.API/Mappings/UserLookupRequestProfile.cs
+++ b/FlexiForm.API/Mappings/UserLookupRequestProfile.cs
@@ -15,6 +15,8 @@ namespace FlexiForm.API.Mappings
         public UserLookupRequestProfile()
         {
             MapLoginRequest();
+            MapString();
+            MapInt();
         }
 
         /// <summary>
@@ -24,6 +26,24 @@ namespace FlexiForm.API.Mappings
         {
             CreateMap<LoginRequest, UserLookupRequest>()
                 .ForMember(dest => dest.Email, member => member.MapFrom(src => src.Email));
+        }
+
+        /// <summary>
+        /// Configures mapping from a <see cref="string"/> value to a <see cref="UserLookupRequest"/> object.
+        /// </summary>
+        private void MapString()
+        {
+            CreateMap<string, UserLookupRequest>()
+                .ForMember(dest => dest.Email, member => member.MapFrom(src => src));
+        }
+
+        /// <summary>
+        /// Configures mapping from an <see cref="int"/> value to a <see cref="UserLookupRequest"/> object.
+        /// </summary>
+        private void MapInt()
+        {
+            CreateMap<int, UserLookupRequest>()
+                .ForMember(dest => dest.Id, member => member.MapFrom(src => src));
         }
     }
 }

--- a/FlexiForm.API/Mappings/UserProfile.cs
+++ b/FlexiForm.API/Mappings/UserProfile.cs
@@ -15,6 +15,7 @@ namespace FlexiForm.API.Mappings
         public UserProfile()
         {
             MapRegistrationRequest();
+            MapUserUpdateRequest();
         }
 
         /// <summary>
@@ -27,6 +28,18 @@ namespace FlexiForm.API.Mappings
                 .ForMember(dest => dest.LastName, mapper => mapper.MapFrom(src => src.LastName))
                 .ForMember(dest => dest.Email, mapper => mapper.MapFrom(src => src.Email))
                 .ForMember(dest => dest.Password, mapper => mapper.MapFrom(src => src.Password))
+                .ForMember(dest => dest.Gender, mapper => mapper.MapFrom(src => src.Gender));
+        }
+
+        /// <summary>
+        /// Configures the AutoMapper mapping between <see cref="UserUpdateRequest"/> and <see cref="User"/>.
+        /// Maps the FirstName, LastName, and Gender properties from the request to the corresponding entity fields.
+        /// </summary>
+        private void MapUserUpdateRequest()
+        {
+            CreateMap<UserUpdateRequest, User>()
+                .ForMember(dest => dest.FirstName, mapper => mapper.MapFrom(src => src.FirstName))
+                .ForMember(dest => dest.LastName, mapper => mapper.MapFrom(src => src.LastName))
                 .ForMember(dest => dest.Gender, mapper => mapper.MapFrom(src => src.Gender));
         }
     }

--- a/FlexiForm.API/Repositories/Implementations/UserRepository.cs
+++ b/FlexiForm.API/Repositories/Implementations/UserRepository.cs
@@ -64,5 +64,23 @@ namespace FlexiForm.API.Repositories.Implementations
 
             return await _repository.QuerySingleOrDefaultAsync<User>(procedure);
         }
+
+        /// <inheritdoc/>
+        public async Task UpdateAsync(User user)
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("@id", user.RowId);
+            parameters.Add("@firstname", user.FirstName);
+            parameters.Add("@lastname", user.LastName);
+            parameters.Add("@gender", Convert.ToByte(user.Gender));
+
+            var procedure = new StoredProcedure()
+            {
+                Name = "usp_updateuser",
+                Parameters = parameters
+            };
+
+            await _repository.ExecuteAsync(procedure);
+        }
     }
 }

--- a/FlexiForm.API/Repositories/Interfaces/IUserRepository.cs
+++ b/FlexiForm.API/Repositories/Interfaces/IUserRepository.cs
@@ -29,5 +29,14 @@ namespace FlexiForm.API.Repositories.Interfaces
         /// or <c>null</c> if no user is found.
         /// </returns>
         Task<User> GetAsync(UserLookupRequest request);
+
+        /// <summary>
+        /// Asynchronously updates an existing user record in the database.
+        /// </summary>
+        /// <param name="user">The <see cref="User"/> object containing updated user information. The user must have a valid identifier.</param>
+        /// <returns>
+        /// A task that represents the asynchronous update operation.
+        /// </returns>
+        Task UpdateAsync(User user);
     }
 }

--- a/FlexiForm.API/Services/Implementations/UserService.cs
+++ b/FlexiForm.API/Services/Implementations/UserService.cs
@@ -177,16 +177,16 @@ namespace FlexiForm.API.Services.Implementations
         /// Throws an exception if the gender is invalid.
         /// </summary>
         /// <param name="gender">The gender value to validate.</param>
-        private static void ValidateGender(Gender? gender)
+        private static void ValidateGender(Gender gender)
         {
-            if (!gender.HasValue)
+            if (gender == Gender.None)
             {
                 throw new GenderRequiredException();
             }
 
-            if (!Enum.IsDefined(typeof(Gender), gender.Value))
+            if (!Enum.IsDefined(typeof(Gender), gender))
             {
-                throw new InvalidGenderException(gender.Value);
+                throw new InvalidGenderException(gender);
             }
         }
     }

--- a/FlexiForm.API/Services/Interfaces/IUserService.cs
+++ b/FlexiForm.API/Services/Interfaces/IUserService.cs
@@ -27,5 +27,16 @@ namespace FlexiForm.API.Services.Interfaces
         /// containing the user's data if found; otherwise, <c>null</c>.
         /// </returns>
         Task<UserResponse> GetAsync(int id);
+
+        /// <summary>
+        /// Updates the profile information of a user with the specified identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the user to update.</param>
+        /// <param name="request">An object containing the updated user details.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. 
+        /// The task result contains a <see cref="UserResponse"/> object with the updated user information.
+        /// </returns>
+        Task<UserResponse> UpdateAsync(int id, UserUpdateRequest request);
     }
 }


### PR DESCRIPTION
#### ✅ Summary

This PR implements the user profile update functionality as described in the feature ticket. It enables authenticated users to securely update their profile information via the `PUT /api/users/{id}` endpoint while enforcing proper validation and authorization policies.

#### 🔧 Implemented Changes

* Created `PUT /api/users/{id}` endpoint for user profile updates
* Accepted and validated the following user fields:

  * `FirstName`
  * `LastName`
  * `Gender`
* Ensured user existence before processing the update
* Applied `ProfileOwner` authorization policy to restrict access to the profile owner
* Updated user data in the database
* Returned updated user profile (excluding sensitive fields) in a standardized response format
* Returned appropriate error responses for invalid scenarios (`400`, `403`, `404`)

#### 🔐 Security

* Protected endpoint with `[Authorize(Policy = ProfileOwner)]`
* Restricted updates to only permitted fields (email and password cannot be updated here)
* Ensured no sensitive data (like password hash or internal identifiers) is exposed in the response

#### 🧪 Acceptance Criteria Covered

✅ Validates existence of user with provided ID
✅ Ensures only the profile owner (or authorized role) can update
✅ Returns `200 OK` with updated user data
✅ Returns `404 Not Found` if user does not exist
✅ Returns `400 Bad Request` for invalid input
✅ Returns `403 Forbidden` if not authorized
✅ Excludes sensitive fields (e.g., password, email) from response